### PR TITLE
Update SQL Database architecture to allow many-to-many relationships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'Dockerfile'
+      - 'database/**'
       - '.github/workflows/ci.yml'
   pull_request:
     branches: [master, main]
@@ -16,6 +17,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'Dockerfile'
+      - 'database/**'
       - '.github/workflows/ci.yml'
 
 # Cancel in-progress runs when a new run is triggered
@@ -100,6 +102,7 @@ jobs:
         run: |
           mysql -h 127.0.0.1 -u root -pmysql alertsnitch < database/mysql/0.0.1-bootstrap.sql
           mysql -h 127.0.0.1 -u root -pmysql alertsnitch < database/mysql/0.1.0-fingerprint.sql
+          mysql -h 127.0.0.1 -u root -pmysql alertsnitch < database/mysql/0.2.0-labelkv.sql
 
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out ./...
@@ -136,6 +139,7 @@ jobs:
         run: |
           PGPASSWORD=postgres psql -h 127.0.0.1 -U runner -d alertsnitch -f database/postgres/0.0.1-bootstrap.sql
           PGPASSWORD=postgres psql -h 127.0.0.1 -U runner -d alertsnitch -f database/postgres/0.1.0-fingerprint.sql
+          PGPASSWORD=postgres psql -h 127.0.0.1 -U runner -d alertsnitch -f database/postgres/0.2.0-labelkv.sql
 
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
           mysql -h 127.0.0.1 -u root -pmysql alertsnitch < database/mysql/0.0.1-bootstrap.sql
           mysql -h 127.0.0.1 -u root -pmysql alertsnitch < database/mysql/0.1.0-fingerprint.sql
           mysql -h 127.0.0.1 -u root -pmysql alertsnitch < database/mysql/0.2.0-labelkv.sql
+          mysql -h 127.0.0.1 -u root -pmysql alertsnitch < database/mysql/0.3.0-alertgroup-kv.sql
 
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out ./...
@@ -140,6 +141,7 @@ jobs:
           PGPASSWORD=postgres psql -h 127.0.0.1 -U runner -d alertsnitch -f database/postgres/0.0.1-bootstrap.sql
           PGPASSWORD=postgres psql -h 127.0.0.1 -U runner -d alertsnitch -f database/postgres/0.1.0-fingerprint.sql
           PGPASSWORD=postgres psql -h 127.0.0.1 -U runner -d alertsnitch -f database/postgres/0.2.0-labelkv.sql
+          PGPASSWORD=postgres psql -h 127.0.0.1 -U runner -d alertsnitch -f database/postgres/0.3.0-alertgroup-kv.sql
 
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out ./...

--- a/database/bootstrap_mysql.sh
+++ b/database/bootstrap_mysql.sh
@@ -12,4 +12,7 @@ mysql --user=root --password="${MYSQL_ROOT_PASSWORD}" --host=mysql "${MYSQL_DATA
 echo "Applying fingerprint model update"
 mysql --user=root --password="${MYSQL_ROOT_PASSWORD}" --host=mysql "${MYSQL_DATABASE}" < mysql/0.1.0-fingerprint.sql
 
+echo "Applying label/annotation KV deduplication"
+mysql --user=root --password="${MYSQL_ROOT_PASSWORD}" --host=mysql "${MYSQL_DATABASE}" < mysql/0.2.0-labelkv.sql
+
 echo "Done creating model"

--- a/database/bootstrap_mysql.sh
+++ b/database/bootstrap_mysql.sh
@@ -15,4 +15,7 @@ mysql --user=root --password="${MYSQL_ROOT_PASSWORD}" --host=mysql "${MYSQL_DATA
 echo "Applying label/annotation KV deduplication"
 mysql --user=root --password="${MYSQL_ROOT_PASSWORD}" --host=mysql "${MYSQL_DATABASE}" < mysql/0.2.0-labelkv.sql
 
+echo "Applying AlertGroup receiver/externalURL/groupKey KV lookup"
+mysql --user=root --password="${MYSQL_ROOT_PASSWORD}" --host=mysql "${MYSQL_DATABASE}" < mysql/0.3.0-alertgroup-kv.sql
+
 echo "Done creating model"

--- a/database/bootstrap_postgres.sh
+++ b/database/bootstrap_postgres.sh
@@ -9,4 +9,7 @@ psql -h "postgres" -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -f postgres/0.0.1-b
 echo "Applying fingerprint model update"
 psql -h "postgres" -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -f postgres/0.1.0-fingerprint.sql
 
+echo "Applying label/annotation KV deduplication"
+psql -h "postgres" -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -f postgres/0.2.0-labelkv.sql
+
 echo "Done creating model"

--- a/database/bootstrap_postgres.sh
+++ b/database/bootstrap_postgres.sh
@@ -12,4 +12,7 @@ psql -h "postgres" -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -f postgres/0.1.0-f
 echo "Applying label/annotation KV deduplication"
 psql -h "postgres" -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -f postgres/0.2.0-labelkv.sql
 
+echo "Applying AlertGroup receiver/externalURL/groupKey KV lookup"
+psql -h "postgres" -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -f postgres/0.3.0-alertgroup-kv.sql
+
 echo "Done creating model"

--- a/database/mysql/0.2.0-labelkv.sql
+++ b/database/mysql/0.2.0-labelkv.sql
@@ -1,0 +1,92 @@
+-- Deduplicate label and annotation key/value pairs via lookup tables.
+-- KvHash is MD5(hex) of key || ASCII SOH || value so unique indexes stay within engine limits.
+
+CREATE TABLE `LabelKV` (
+    `ID` INT NOT NULL AUTO_INCREMENT,
+    `LabelKey` VARCHAR(100) NOT NULL,
+    `Value` VARCHAR(1000) NOT NULL,
+    `KvHash` CHAR(32) NOT NULL,
+    PRIMARY KEY (`ID`),
+    UNIQUE KEY `LabelKV_KvHash` (`KvHash`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `AnnotationKV` (
+    `ID` INT NOT NULL AUTO_INCREMENT,
+    `AnnotationKey` VARCHAR(100) NOT NULL,
+    `Value` VARCHAR(1000) NOT NULL,
+    `KvHash` CHAR(32) NOT NULL,
+    PRIMARY KEY (`ID`),
+    UNIQUE KEY `AnnotationKV_KvHash` (`KvHash`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT IGNORE INTO `LabelKV` (`LabelKey`, `Value`, `KvHash`)
+SELECT DISTINCT `GroupLabel`, `Value`, MD5(CONCAT(`GroupLabel`, CHAR(1), `Value`)) FROM `GroupLabel`;
+
+INSERT IGNORE INTO `LabelKV` (`LabelKey`, `Value`, `KvHash`)
+SELECT DISTINCT `Label`, `Value`, MD5(CONCAT(`Label`, CHAR(1), `Value`)) FROM `CommonLabel`;
+
+INSERT IGNORE INTO `LabelKV` (`LabelKey`, `Value`, `KvHash`)
+SELECT DISTINCT `Label`, `Value`, MD5(CONCAT(`Label`, CHAR(1), `Value`)) FROM `AlertLabel`;
+
+INSERT IGNORE INTO `AnnotationKV` (`AnnotationKey`, `Value`, `KvHash`)
+SELECT DISTINCT `Annotation`, `Value`, MD5(CONCAT(`Annotation`, CHAR(1), `Value`)) FROM `CommonAnnotation`;
+
+INSERT IGNORE INTO `AnnotationKV` (`AnnotationKey`, `Value`, `KvHash`)
+SELECT DISTINCT `Annotation`, `Value`, MD5(CONCAT(`Annotation`, CHAR(1), `Value`)) FROM `AlertAnnotation`;
+
+ALTER TABLE `GroupLabel` ADD COLUMN `LabelKVID` INT NULL;
+UPDATE `GroupLabel` gl
+INNER JOIN `LabelKV` lk ON gl.`GroupLabel` = lk.`LabelKey` AND gl.`Value` = lk.`Value`
+SET gl.`LabelKVID` = lk.`ID`;
+ALTER TABLE `GroupLabel`
+    DROP COLUMN `GroupLabel`,
+    DROP COLUMN `Value`,
+    MODIFY COLUMN `LabelKVID` INT NOT NULL,
+    ADD CONSTRAINT `fk_grouplabel_labelkv` FOREIGN KEY (`LabelKVID`) REFERENCES `LabelKV` (`ID`) ON DELETE RESTRICT,
+    ADD UNIQUE KEY `GroupLabel_alertgroup_labelkv` (`AlertGroupID`, `LabelKVID`);
+
+ALTER TABLE `CommonLabel` ADD COLUMN `LabelKVID` INT NULL;
+UPDATE `CommonLabel` cl
+INNER JOIN `LabelKV` lk ON cl.`Label` = lk.`LabelKey` AND cl.`Value` = lk.`Value`
+SET cl.`LabelKVID` = lk.`ID`;
+ALTER TABLE `CommonLabel`
+    DROP COLUMN `Label`,
+    DROP COLUMN `Value`,
+    MODIFY COLUMN `LabelKVID` INT NOT NULL,
+    ADD CONSTRAINT `fk_commonlabel_labelkv` FOREIGN KEY (`LabelKVID`) REFERENCES `LabelKV` (`ID`) ON DELETE RESTRICT,
+    ADD UNIQUE KEY `CommonLabel_alertgroup_labelkv` (`AlertGroupID`, `LabelKVID`);
+
+ALTER TABLE `CommonAnnotation` ADD COLUMN `AnnotationKVID` INT NULL;
+UPDATE `CommonAnnotation` ca
+INNER JOIN `AnnotationKV` ak ON ca.`Annotation` = ak.`AnnotationKey` AND ca.`Value` = ak.`Value`
+SET ca.`AnnotationKVID` = ak.`ID`;
+ALTER TABLE `CommonAnnotation`
+    DROP COLUMN `Annotation`,
+    DROP COLUMN `Value`,
+    MODIFY COLUMN `AnnotationKVID` INT NOT NULL,
+    ADD CONSTRAINT `fk_commonannotation_annkv` FOREIGN KEY (`AnnotationKVID`) REFERENCES `AnnotationKV` (`ID`) ON DELETE RESTRICT,
+    ADD UNIQUE KEY `CommonAnnotation_alertgroup_annkv` (`AlertGroupID`, `AnnotationKVID`);
+
+ALTER TABLE `AlertLabel` ADD COLUMN `LabelKVID` INT NULL;
+UPDATE `AlertLabel` al
+INNER JOIN `LabelKV` lk ON al.`Label` = lk.`LabelKey` AND al.`Value` = lk.`Value`
+SET al.`LabelKVID` = lk.`ID`;
+ALTER TABLE `AlertLabel`
+    DROP COLUMN `Label`,
+    DROP COLUMN `Value`,
+    MODIFY COLUMN `LabelKVID` INT NOT NULL,
+    ADD CONSTRAINT `fk_alertlabel_labelkv` FOREIGN KEY (`LabelKVID`) REFERENCES `LabelKV` (`ID`) ON DELETE RESTRICT,
+    ADD UNIQUE KEY `AlertLabel_alert_labelkv` (`AlertID`, `LabelKVID`);
+
+ALTER TABLE `AlertAnnotation` ADD COLUMN `AnnotationKVID` INT NULL;
+UPDATE `AlertAnnotation` aa
+INNER JOIN `AnnotationKV` ak ON aa.`Annotation` = ak.`AnnotationKey` AND aa.`Value` = ak.`Value`
+SET aa.`AnnotationKVID` = ak.`ID`;
+ALTER TABLE `AlertAnnotation`
+    DROP COLUMN `Annotation`,
+    DROP COLUMN `Value`,
+    MODIFY COLUMN `AnnotationKVID` INT NOT NULL,
+    ADD CONSTRAINT `fk_alertannotation_annkv` FOREIGN KEY (`AnnotationKVID`) REFERENCES `AnnotationKV` (`ID`) ON DELETE RESTRICT,
+    ADD UNIQUE KEY `AlertAnnotation_alert_annkv` (`AlertID`, `AnnotationKVID`);
+
+UPDATE `Model` SET `version` = '0.2.0';

--- a/database/mysql/0.3.0-alertgroup-kv.sql
+++ b/database/mysql/0.3.0-alertgroup-kv.sql
@@ -1,0 +1,61 @@
+-- Deduplicate AlertGroup receiver, externalURL, and groupKey via lookup tables.
+
+CREATE TABLE `AlertGroupReceiver` (
+    `ID` INT NOT NULL AUTO_INCREMENT,
+    `Receiver` VARCHAR(100) NOT NULL,
+    PRIMARY KEY (`ID`),
+    UNIQUE KEY `AlertGroupReceiver_Receiver` (`Receiver`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- VARCHAR(1000) utf8 keeps the unique index within InnoDB's key length limit (TEXT cannot be fully unique in MySQL).
+CREATE TABLE `AlertGroupExternalURL` (
+    `ID` INT NOT NULL AUTO_INCREMENT,
+    `ExternalURL` VARCHAR(1000) CHARACTER SET utf8 NOT NULL,
+    PRIMARY KEY (`ID`),
+    UNIQUE KEY `AlertGroupExternalURL_ExternalURL` (`ExternalURL`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `AlertGroupKey` (
+    `ID` INT NOT NULL AUTO_INCREMENT,
+    `GroupKey` VARCHAR(255) NOT NULL,
+    PRIMARY KEY (`ID`),
+    UNIQUE KEY `AlertGroupKey_GroupKey` (`GroupKey`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT IGNORE INTO `AlertGroupReceiver` (`Receiver`)
+SELECT DISTINCT `receiver` FROM `AlertGroup`;
+
+INSERT IGNORE INTO `AlertGroupExternalURL` (`ExternalURL`)
+SELECT DISTINCT `externalURL` FROM `AlertGroup`;
+
+INSERT IGNORE INTO `AlertGroupKey` (`GroupKey`)
+SELECT DISTINCT `groupKey` FROM `AlertGroup`;
+
+ALTER TABLE `AlertGroup` ADD COLUMN `ReceiverID` INT NULL;
+ALTER TABLE `AlertGroup` ADD COLUMN `ExternalURLID` INT NULL;
+ALTER TABLE `AlertGroup` ADD COLUMN `KeyID` INT NULL;
+
+UPDATE `AlertGroup` ag
+INNER JOIN `AlertGroupReceiver` rk ON ag.`receiver` = rk.`Receiver`
+SET ag.`ReceiverID` = rk.`ID`;
+
+UPDATE `AlertGroup` ag
+INNER JOIN `AlertGroupExternalURL` ek ON ag.`externalURL` = ek.`ExternalURL`
+SET ag.`ExternalURLID` = ek.`ID`;
+
+UPDATE `AlertGroup` ag
+INNER JOIN `AlertGroupKey` gk ON ag.`groupKey` = gk.`GroupKey`
+SET ag.`KeyID` = gk.`ID`;
+
+ALTER TABLE `AlertGroup`
+    DROP COLUMN `receiver`,
+    DROP COLUMN `externalURL`,
+    DROP COLUMN `groupKey`,
+    MODIFY COLUMN `ReceiverID` INT NOT NULL,
+    MODIFY COLUMN `ExternalURLID` INT NOT NULL,
+    MODIFY COLUMN `KeyID` INT NOT NULL,
+    ADD CONSTRAINT `fk_alertgroup_AlertGroupReceiver` FOREIGN KEY (`ReceiverID`) REFERENCES `AlertGroupReceiver` (`ID`) ON DELETE RESTRICT,
+    ADD CONSTRAINT `fk_alertgroup_AlertGroupExternalURL` FOREIGN KEY (`ExternalURLID`) REFERENCES `AlertGroupExternalURL` (`ID`) ON DELETE RESTRICT,
+    ADD CONSTRAINT `fk_alertgroup_AlertGroupKey` FOREIGN KEY (`KeyID`) REFERENCES `AlertGroupKey` (`ID`) ON DELETE RESTRICT;
+
+UPDATE `Model` SET `version` = '0.3.0';

--- a/database/postgres/0.2.0-labelkv.sql
+++ b/database/postgres/0.2.0-labelkv.sql
@@ -1,0 +1,95 @@
+-- Deduplicate label and annotation key/value pairs via lookup tables.
+-- KvHash is MD5(hex) of key || ASCII SOH || value so unique indexes stay within engine limits (NUL is invalid in PG text).
+
+CREATE TABLE LabelKV (
+    ID SERIAL NOT NULL PRIMARY KEY,
+    LabelKey VARCHAR(100) NOT NULL,
+    Value VARCHAR(1000) NOT NULL,
+    KvHash CHAR(32) NOT NULL,
+    CONSTRAINT LabelKV_KvHash_key UNIQUE (KvHash)
+);
+
+CREATE TABLE AnnotationKV (
+    ID SERIAL NOT NULL PRIMARY KEY,
+    AnnotationKey VARCHAR(100) NOT NULL,
+    Value VARCHAR(1000) NOT NULL,
+    KvHash CHAR(32) NOT NULL,
+    CONSTRAINT AnnotationKV_KvHash_key UNIQUE (KvHash)
+);
+
+INSERT INTO LabelKV (LabelKey, Value, KvHash)
+SELECT DISTINCT gl.grouplabel, gl.value, md5(gl.grouplabel || chr(1) || gl.value)
+FROM GroupLabel gl
+ON CONFLICT (KvHash) DO NOTHING;
+
+INSERT INTO LabelKV (LabelKey, Value, KvHash)
+SELECT DISTINCT cl.label, cl.value, md5(cl.label || chr(1) || cl.value)
+FROM CommonLabel cl
+ON CONFLICT (KvHash) DO NOTHING;
+
+INSERT INTO LabelKV (LabelKey, Value, KvHash)
+SELECT DISTINCT al.label, al.value, md5(al.label || chr(1) || al.value)
+FROM AlertLabel al
+ON CONFLICT (KvHash) DO NOTHING;
+
+INSERT INTO AnnotationKV (AnnotationKey, Value, KvHash)
+SELECT DISTINCT ca.annotation, ca.value, md5(ca.annotation || chr(1) || ca.value)
+FROM CommonAnnotation ca
+ON CONFLICT (KvHash) DO NOTHING;
+
+INSERT INTO AnnotationKV (AnnotationKey, Value, KvHash)
+SELECT DISTINCT aa.annotation, aa.value, md5(aa.annotation || chr(1) || aa.value)
+FROM AlertAnnotation aa
+ON CONFLICT (KvHash) DO NOTHING;
+
+ALTER TABLE GroupLabel ADD COLUMN LabelKVID INTEGER;
+UPDATE GroupLabel gl SET LabelKVID = lk.ID
+FROM LabelKV lk
+WHERE lk.LabelKey = gl.grouplabel AND lk.Value = gl.value;
+ALTER TABLE GroupLabel DROP COLUMN grouplabel, DROP COLUMN value;
+ALTER TABLE GroupLabel ALTER COLUMN LabelKVID SET NOT NULL;
+ALTER TABLE GroupLabel
+    ADD CONSTRAINT GroupLabel_LabelKVID_fkey FOREIGN KEY (LabelKVID) REFERENCES LabelKV (ID);
+CREATE UNIQUE INDEX GroupLabel_alertgroup_labelkv_idx ON GroupLabel (AlertGroupID, LabelKVID);
+
+ALTER TABLE CommonLabel ADD COLUMN LabelKVID INTEGER;
+UPDATE CommonLabel cl SET LabelKVID = lk.ID
+FROM LabelKV lk
+WHERE lk.LabelKey = cl.label AND lk.Value = cl.value;
+ALTER TABLE CommonLabel DROP COLUMN label, DROP COLUMN value;
+ALTER TABLE CommonLabel ALTER COLUMN LabelKVID SET NOT NULL;
+ALTER TABLE CommonLabel
+    ADD CONSTRAINT CommonLabel_LabelKVID_fkey FOREIGN KEY (LabelKVID) REFERENCES LabelKV (ID);
+CREATE UNIQUE INDEX CommonLabel_alertgroup_labelkv_idx ON CommonLabel (AlertGroupID, LabelKVID);
+
+ALTER TABLE CommonAnnotation ADD COLUMN AnnotationKVID INTEGER;
+UPDATE CommonAnnotation ca SET AnnotationKVID = ak.ID
+FROM AnnotationKV ak
+WHERE ak.AnnotationKey = ca.annotation AND ak.Value = ca.value;
+ALTER TABLE CommonAnnotation DROP COLUMN annotation, DROP COLUMN value;
+ALTER TABLE CommonAnnotation ALTER COLUMN AnnotationKVID SET NOT NULL;
+ALTER TABLE CommonAnnotation
+    ADD CONSTRAINT CommonAnnotation_AnnotationKVID_fkey FOREIGN KEY (AnnotationKVID) REFERENCES AnnotationKV (ID);
+CREATE UNIQUE INDEX CommonAnnotation_alertgroup_annkv_idx ON CommonAnnotation (AlertGroupID, AnnotationKVID);
+
+ALTER TABLE AlertLabel ADD COLUMN LabelKVID INTEGER;
+UPDATE AlertLabel al SET LabelKVID = lk.ID
+FROM LabelKV lk
+WHERE lk.LabelKey = al.label AND lk.Value = al.value;
+ALTER TABLE AlertLabel DROP COLUMN label, DROP COLUMN value;
+ALTER TABLE AlertLabel ALTER COLUMN LabelKVID SET NOT NULL;
+ALTER TABLE AlertLabel
+    ADD CONSTRAINT AlertLabel_LabelKVID_fkey FOREIGN KEY (LabelKVID) REFERENCES LabelKV (ID);
+CREATE UNIQUE INDEX AlertLabel_alert_labelkv_idx ON AlertLabel (AlertID, LabelKVID);
+
+ALTER TABLE AlertAnnotation ADD COLUMN AnnotationKVID INTEGER;
+UPDATE AlertAnnotation aa SET AnnotationKVID = ak.ID
+FROM AnnotationKV ak
+WHERE ak.AnnotationKey = aa.annotation AND ak.Value = aa.value;
+ALTER TABLE AlertAnnotation DROP COLUMN annotation, DROP COLUMN value;
+ALTER TABLE AlertAnnotation ALTER COLUMN AnnotationKVID SET NOT NULL;
+ALTER TABLE AlertAnnotation
+    ADD CONSTRAINT AlertAnnotation_AnnotationKVID_fkey FOREIGN KEY (AnnotationKVID) REFERENCES AnnotationKV (ID);
+CREATE UNIQUE INDEX AlertAnnotation_alert_annkv_idx ON AlertAnnotation (AlertID, AnnotationKVID);
+
+UPDATE Model SET version = '0.2.0';

--- a/database/postgres/0.3.0-alertgroup-kv.sql
+++ b/database/postgres/0.3.0-alertgroup-kv.sql
@@ -1,0 +1,61 @@
+-- Deduplicate AlertGroup receiver, externalURL, and groupKey via lookup tables.
+
+CREATE TABLE AlertGroupReceiver (
+    ID SERIAL NOT NULL PRIMARY KEY,
+    Receiver VARCHAR(100) NOT NULL,
+    CONSTRAINT AlertGroupReceiver_Receiver_key UNIQUE (Receiver)
+);
+
+CREATE TABLE AlertGroupExternalURL (
+    ID SERIAL NOT NULL PRIMARY KEY,
+    ExternalURL TEXT NOT NULL,
+    CONSTRAINT AlertGroupExternalURL_ExternalURL_key UNIQUE (ExternalURL)
+);
+
+CREATE TABLE AlertGroupKey (
+    ID SERIAL NOT NULL PRIMARY KEY,
+    GroupKey VARCHAR(255) NOT NULL,
+    CONSTRAINT AlertGroupKey_GroupKey_key UNIQUE (GroupKey)
+);
+
+INSERT INTO AlertGroupReceiver (Receiver)
+SELECT DISTINCT receiver
+FROM AlertGroup
+ON CONFLICT (Receiver) DO NOTHING;
+
+INSERT INTO AlertGroupExternalURL (ExternalURL)
+SELECT DISTINCT externalurl
+FROM AlertGroup
+ON CONFLICT (ExternalURL) DO NOTHING;
+
+INSERT INTO AlertGroupKey (GroupKey)
+SELECT DISTINCT groupkey
+FROM AlertGroup
+ON CONFLICT (GroupKey) DO NOTHING;
+
+ALTER TABLE AlertGroup ADD COLUMN ReceiverID INTEGER;
+ALTER TABLE AlertGroup ADD COLUMN ExternalURLID INTEGER;
+ALTER TABLE AlertGroup ADD COLUMN KeyID INTEGER;
+
+UPDATE AlertGroup ag SET ReceiverID = rk.ID
+FROM AlertGroupReceiver rk
+WHERE ag.receiver = rk.Receiver;
+
+UPDATE AlertGroup ag SET ExternalURLID = ek.ID
+FROM AlertGroupExternalURL ek
+WHERE ag.externalurl = ek.ExternalURL;
+
+UPDATE AlertGroup ag SET KeyID = gk.ID
+FROM AlertGroupKey gk
+WHERE ag.groupkey = gk.GroupKey;
+
+ALTER TABLE AlertGroup DROP COLUMN receiver, DROP COLUMN externalurl, DROP COLUMN groupkey;
+ALTER TABLE AlertGroup ALTER COLUMN ReceiverID SET NOT NULL;
+ALTER TABLE AlertGroup ALTER COLUMN ExternalURLID SET NOT NULL;
+ALTER TABLE AlertGroup ALTER COLUMN KeyID SET NOT NULL;
+ALTER TABLE AlertGroup
+    ADD CONSTRAINT AlertGroup_ReceiverID_fkey FOREIGN KEY (ReceiverID) REFERENCES AlertGroupReceiver (ID),
+    ADD CONSTRAINT AlertGroup_ExternalURLID_fkey FOREIGN KEY (ExternalURLID) REFERENCES AlertGroupExternalURL (ID),
+    ADD CONSTRAINT AlertGroup_KeyID_fkey FOREIGN KEY (KeyID) REFERENCES AlertGroupKey (ID);
+
+UPDATE Model SET version = '0.3.0';

--- a/example/grafana/dashboards/alert-history-with-mysql.json
+++ b/example/grafana/dashboards/alert-history-with-mysql.json
@@ -353,7 +353,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"severity\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"firing\"\n\t)\n\tAND Label=\"severity\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"severity\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"firing\"\n\t)\n\tAND lkv.LabelKey=\"severity\"",
           "refId": "D",
           "select": [
             [
@@ -708,7 +708,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"severity\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"resolved\"\n\t)\n\tAND Label=\"severity\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"severity\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"resolved\"\n\t)\n\tAND lkv.LabelKey=\"severity\"",
           "refId": "D",
           "select": [
             [
@@ -1277,7 +1277,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"alertname\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND Label=\"alertname\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"alertname\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND lkv.LabelKey=\"alertname\"",
           "refId": "B",
           "select": [
             [
@@ -1310,7 +1310,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"env\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND Label=\"env\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"env\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND lkv.LabelKey=\"env\"",
           "refId": "C",
           "select": [
             [
@@ -1343,7 +1343,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"severity\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND Label=\"severity\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"severity\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND lkv.LabelKey=\"severity\"",
           "refId": "D",
           "select": [
             [
@@ -1376,7 +1376,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"az\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND Label=\"az\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"az\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND lkv.LabelKey=\"az\"",
           "refId": "E",
           "select": [
             [
@@ -1409,7 +1409,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"hostname\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND Label=\"hostname\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"hostname\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND lkv.LabelKey=\"hostname\"",
           "refId": "F",
           "select": [
             [
@@ -1442,7 +1442,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"project\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND Label=\"project\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"project\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND lkv.LabelKey=\"project\"",
           "refId": "G",
           "select": [
             [
@@ -1475,7 +1475,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"description\"\nFROM\n\tAlertAnnotation\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND Annotation=\"description\"",
+          "rawSql": "SELECT\n\taa.AlertID AS \"ID\",\n\takv.Value AS \"description\"\nFROM\n\tAlertAnnotation aa\n\tINNER JOIN AnnotationKV akv ON aa.AnnotationKVID = akv.ID\nWHERE\n\taa.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND akv.AnnotationKey=\"description\"",
           "refId": "H",
           "select": [
             [
@@ -1790,7 +1790,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"alertname\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"resolved\"\n\t)\n\tAND Label=\"alertname\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"alertname\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"resolved\"\n\t)\n\tAND lkv.LabelKey=\"alertname\"",
           "refId": "B",
           "select": [
             [
@@ -1823,7 +1823,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"env\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"resolved\"\n\t)\n\tAND Label=\"env\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"env\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"resolved\"\n\t)\n\tAND lkv.LabelKey=\"env\"",
           "refId": "C",
           "select": [
             [
@@ -1856,7 +1856,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"severity\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"resolved\"\n\t)\n\tAND Label=\"severity\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"severity\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"resolved\"\n\t)\n\tAND lkv.LabelKey=\"severity\"",
           "refId": "D",
           "select": [
             [
@@ -1889,7 +1889,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"az\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"resolved\"\n\t)\n\tAND Label=\"az\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"az\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"resolved\"\n\t)\n\tAND lkv.LabelKey=\"az\"",
           "refId": "E",
           "select": [
             [
@@ -1922,7 +1922,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"hostname\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"resolved\"\n\t)\n\tAND Label=\"hostname\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"hostname\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"resolved\"\n\t)\n\tAND lkv.LabelKey=\"hostname\"",
           "refId": "F",
           "select": [
             [
@@ -1955,7 +1955,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"project\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"resolved\"\n\t)\n\tAND Label=\"project\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"project\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"resolved\"\n\t)\n\tAND lkv.LabelKey=\"project\"",
           "refId": "G",
           "select": [
             [
@@ -1988,7 +1988,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"description\"\nFROM\n\tAlertAnnotation\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"resolved\"\n\t)\n\tAND Annotation=\"description\"",
+          "rawSql": "SELECT\n\taa.AlertID AS \"ID\",\n\takv.Value AS \"description\"\nFROM\n\tAlertAnnotation aa\n\tINNER JOIN AnnotationKV akv ON aa.AnnotationKVID = akv.ID\nWHERE\n\taa.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t  AND status=\"resolved\"\n\t)\n\tAND akv.AnnotationKey=\"description\"",
           "refId": "H",
           "select": [
             [
@@ -2225,7 +2225,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"alertname\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND Label=\"alertname\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"alertname\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND lkv.LabelKey=\"alertname\"",
           "refId": "B",
           "select": [
             [
@@ -2258,7 +2258,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"env\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND Label=\"env\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"env\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND lkv.LabelKey=\"env\"",
           "refId": "C",
           "select": [
             [
@@ -2291,7 +2291,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"severity\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND Label=\"severity\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"severity\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND lkv.LabelKey=\"severity\"",
           "refId": "D",
           "select": [
             [
@@ -2324,7 +2324,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"az\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND Label=\"az\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"az\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND lkv.LabelKey=\"az\"",
           "refId": "E",
           "select": [
             [
@@ -2357,7 +2357,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"hostname\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND Label=\"hostname\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"hostname\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND lkv.LabelKey=\"hostname\"",
           "refId": "F",
           "select": [
             [
@@ -2390,7 +2390,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"project\"\nFROM\n\tAlertLabel\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND Label=\"project\"",
+          "rawSql": "SELECT\n\tal.AlertID AS \"ID\",\n\tlkv.Value AS \"project\"\nFROM\n\tAlertLabel al\n\tINNER JOIN LabelKV lkv ON al.LabelKVID = lkv.ID\nWHERE\n\tal.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND lkv.LabelKey=\"project\"",
           "refId": "G",
           "select": [
             [
@@ -2423,7 +2423,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\tAlertID AS \"ID\",\n\tValue AS \"description\"\nFROM\n\tAlertAnnotation\nWHERE\n\tAlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND Annotation=\"description\"",
+          "rawSql": "SELECT\n\taa.AlertID AS \"ID\",\n\takv.Value AS \"description\"\nFROM\n\tAlertAnnotation aa\n\tINNER JOIN AnnotationKV akv ON aa.AnnotationKVID = akv.ID\nWHERE\n\taa.AlertID IN (\n\tSELECT\n\t\tID \n\tFROM\n\t\tAlert \n\tWHERE\n\t  startsAt BETWEEN DATE_SUB(FROM_UNIXTIME(${__from:date:seconds}),INTERVAL 8 HOUR) AND DATE_SUB(FROM_UNIXTIME(${__to:date:seconds}),INTERVAL 8 HOUR)\n\t)\n\tAND akv.AnnotationKey=\"description\"",
           "refId": "H",
           "select": [
             [

--- a/internal/storage/sqlstore/kv.go
+++ b/internal/storage/sqlstore/kv.go
@@ -52,3 +52,57 @@ func mysqlGetAnnotationKVID(ctx context.Context, tx *sql.Tx, k, v string) (int64
 	err := tx.QueryRowContext(ctx, `SELECT ID FROM AnnotationKV WHERE KvHash = ?`, h).Scan(&id)
 	return id, err
 }
+
+func postgresGetReceiverID(ctx context.Context, tx *sql.Tx, receiver string) (int64, error) {
+	var id int64
+	err := tx.QueryRowContext(ctx, `
+		INSERT INTO AlertGroupReceiver (Receiver) VALUES ($1)
+		ON CONFLICT (Receiver) DO UPDATE SET Receiver = AlertGroupReceiver.Receiver
+		RETURNING ID`, receiver).Scan(&id)
+	return id, err
+}
+
+func postgresGetExternalURLID(ctx context.Context, tx *sql.Tx, externalURL string) (int64, error) {
+	var id int64
+	err := tx.QueryRowContext(ctx, `
+		INSERT INTO AlertGroupExternalURL (ExternalURL) VALUES ($1)
+		ON CONFLICT (ExternalURL) DO UPDATE SET ExternalURL = AlertGroupExternalURL.ExternalURL
+		RETURNING ID`, externalURL).Scan(&id)
+	return id, err
+}
+
+func postgresGetKeyID(ctx context.Context, tx *sql.Tx, groupKey string) (int64, error) {
+	var id int64
+	err := tx.QueryRowContext(ctx, `
+		INSERT INTO AlertGroupKey (GroupKey) VALUES ($1)
+		ON CONFLICT (GroupKey) DO UPDATE SET GroupKey = AlertGroupKey.GroupKey
+		RETURNING ID`, groupKey).Scan(&id)
+	return id, err
+}
+
+func mysqlGetReceiverID(ctx context.Context, tx *sql.Tx, receiver string) (int64, error) {
+	if _, err := tx.ExecContext(ctx, `INSERT IGNORE INTO AlertGroupReceiver (Receiver) VALUES (?)`, receiver); err != nil {
+		return 0, err
+	}
+	var id int64
+	err := tx.QueryRowContext(ctx, `SELECT ID FROM AlertGroupReceiver WHERE Receiver = ?`, receiver).Scan(&id)
+	return id, err
+}
+
+func mysqlGetExternalURLID(ctx context.Context, tx *sql.Tx, externalURL string) (int64, error) {
+	if _, err := tx.ExecContext(ctx, `INSERT IGNORE INTO AlertGroupExternalURL (ExternalURL) VALUES (?)`, externalURL); err != nil {
+		return 0, err
+	}
+	var id int64
+	err := tx.QueryRowContext(ctx, `SELECT ID FROM AlertGroupExternalURL WHERE ExternalURL = ?`, externalURL).Scan(&id)
+	return id, err
+}
+
+func mysqlGetKeyID(ctx context.Context, tx *sql.Tx, groupKey string) (int64, error) {
+	if _, err := tx.ExecContext(ctx, `INSERT IGNORE INTO AlertGroupKey (GroupKey) VALUES (?)`, groupKey); err != nil {
+		return 0, err
+	}
+	var id int64
+	err := tx.QueryRowContext(ctx, `SELECT ID FROM AlertGroupKey WHERE GroupKey = ?`, groupKey).Scan(&id)
+	return id, err
+}

--- a/internal/storage/sqlstore/kv.go
+++ b/internal/storage/sqlstore/kv.go
@@ -2,14 +2,14 @@ package sqlstore
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/md5" //nolint:gosec // KvHash dedup digest; must match database/*/0.2.0-labelkv.sql
 	"database/sql"
 	"encoding/hex"
 )
 
 // kvPairHash is a fixed-width digest of key || ASCII SOH || value for unique indexes (MySQL index size limit; PG rejects NUL in text).
 func kvPairHash(k, v string) string {
-	sum := md5.Sum([]byte(k + "\x01" + v))
+	sum := md5.Sum([]byte(k + "\x01" + v)) //nolint:gosec // not for security; fixed-width unique-index key
 	return hex.EncodeToString(sum[:])
 }
 

--- a/internal/storage/sqlstore/kv.go
+++ b/internal/storage/sqlstore/kv.go
@@ -1,0 +1,54 @@
+package sqlstore
+
+import (
+	"context"
+	"crypto/md5"
+	"database/sql"
+	"encoding/hex"
+)
+
+// kvPairHash is a fixed-width digest of key || ASCII SOH || value for unique indexes (MySQL index size limit; PG rejects NUL in text).
+func kvPairHash(k, v string) string {
+	sum := md5.Sum([]byte(k + "\x01" + v))
+	return hex.EncodeToString(sum[:])
+}
+
+func postgresGetLabelKVID(ctx context.Context, tx *sql.Tx, k, v string) (int64, error) {
+	h := kvPairHash(k, v)
+	var id int64
+	err := tx.QueryRowContext(ctx, `
+		INSERT INTO LabelKV (LabelKey, Value, KvHash) VALUES ($1, $2, $3)
+		ON CONFLICT (KvHash) DO UPDATE SET LabelKey = LabelKV.LabelKey
+		RETURNING ID`, k, v, h).Scan(&id)
+	return id, err
+}
+
+func postgresGetAnnotationKVID(ctx context.Context, tx *sql.Tx, k, v string) (int64, error) {
+	h := kvPairHash(k, v)
+	var id int64
+	err := tx.QueryRowContext(ctx, `
+		INSERT INTO AnnotationKV (AnnotationKey, Value, KvHash) VALUES ($1, $2, $3)
+		ON CONFLICT (KvHash) DO UPDATE SET AnnotationKey = AnnotationKV.AnnotationKey
+		RETURNING ID`, k, v, h).Scan(&id)
+	return id, err
+}
+
+func mysqlGetLabelKVID(ctx context.Context, tx *sql.Tx, k, v string) (int64, error) {
+	h := kvPairHash(k, v)
+	if _, err := tx.ExecContext(ctx, `INSERT IGNORE INTO LabelKV (LabelKey, Value, KvHash) VALUES (?, ?, ?)`, k, v, h); err != nil {
+		return 0, err
+	}
+	var id int64
+	err := tx.QueryRowContext(ctx, `SELECT ID FROM LabelKV WHERE KvHash = ?`, h).Scan(&id)
+	return id, err
+}
+
+func mysqlGetAnnotationKVID(ctx context.Context, tx *sql.Tx, k, v string) (int64, error) {
+	h := kvPairHash(k, v)
+	if _, err := tx.ExecContext(ctx, `INSERT IGNORE INTO AnnotationKV (AnnotationKey, Value, KvHash) VALUES (?, ?, ?)`, k, v, h); err != nil {
+		return 0, err
+	}
+	var id int64
+	err := tx.QueryRowContext(ctx, `SELECT ID FROM AnnotationKV WHERE KvHash = ?`, h).Scan(&id)
+	return id, err
+}

--- a/internal/storage/sqlstore/mysql.go
+++ b/internal/storage/sqlstore/mysql.go
@@ -30,9 +30,22 @@ func ConnectMySQL(cfg Config) (*MySQL, error) {
 // Save persists an alert group. extraLabels is ignored by SQL backends.
 func (d *MySQL) Save(ctx context.Context, data *internal.AlertGroup, _ map[string]string) error {
 	err := d.unitOfWork(ctx, func(tx *sql.Tx) error {
+		receiverID, err := mysqlGetReceiverID(ctx, tx, data.Receiver)
+		if err != nil {
+			return fmt.Errorf("failed to resolve AlertGroup AlertGroupReceiver: %w", err)
+		}
+		externalURLID, err := mysqlGetExternalURLID(ctx, tx, data.ExternalURL)
+		if err != nil {
+			return fmt.Errorf("failed to resolve AlertGroup AlertGroupExternalURL: %w", err)
+		}
+		groupKeyID, err := mysqlGetKeyID(ctx, tx, data.GroupKey)
+		if err != nil {
+			return fmt.Errorf("failed to resolve AlertGroup AlertGroupKey: %w", err)
+		}
+
 		r, err := tx.ExecContext(ctx, `
-			INSERT INTO AlertGroup (time, receiver, status, externalURL, groupKey)
-			VALUES (now(), ?, ?, ?, ?)`, data.Receiver, data.Status, data.ExternalURL, data.GroupKey)
+			INSERT INTO AlertGroup (time, status, ReceiverID, ExternalURLID, KeyID)
+			VALUES (now(), ?, ?, ?, ?)`, data.Status, receiverID, externalURLID, groupKeyID)
 		if err != nil {
 			return fmt.Errorf("failed to insert into AlertGroups: %w", err)
 		}

--- a/internal/storage/sqlstore/mysql.go
+++ b/internal/storage/sqlstore/mysql.go
@@ -41,17 +41,17 @@ func (d *MySQL) Save(ctx context.Context, data *internal.AlertGroup, _ map[strin
 			return fmt.Errorf("failed to get AlertGroups inserted id: %w", err)
 		}
 
-		if err := insertKV(ctx, tx, "GroupLabel (alertGroupID, GroupLabel, Value)", alertGroupID, data.GroupLabels); err != nil {
+		if err := insertGroupLabelsMySQL(ctx, tx, alertGroupID, data.GroupLabels); err != nil {
 			return err
 		}
-		if err := insertKV(ctx, tx, "CommonLabel (alertGroupID, Label, Value)", alertGroupID, data.CommonLabels); err != nil {
+		if err := insertCommonLabelsMySQL(ctx, tx, alertGroupID, data.CommonLabels); err != nil {
 			return err
 		}
-		if err := insertKV(ctx, tx, "CommonAnnotation (alertGroupID, Annotation, Value)", alertGroupID, data.CommonAnnotations); err != nil {
+		if err := insertCommonAnnotationsMySQL(ctx, tx, alertGroupID, data.CommonAnnotations); err != nil {
 			return err
 		}
 
-		return insertAlerts(ctx, tx, alertGroupID, data.Alerts)
+		return insertAlertsMySQL(ctx, tx, alertGroupID, data.Alerts)
 	})
 	metrics.RecordSaveOutcome(data.Receiver, data.Status, len(data.Alerts), err)
 	return err
@@ -59,7 +59,7 @@ func (d *MySQL) Save(ctx context.Context, data *internal.AlertGroup, _ map[strin
 
 func (*MySQL) String() string { return "mysql database driver" }
 
-func insertAlerts(ctx context.Context, tx *sql.Tx, alertGroupID int64, alerts []internal.Alert) error {
+func insertAlertsMySQL(ctx context.Context, tx *sql.Tx, alertGroupID int64, alerts []internal.Alert) error {
 	for _, alert := range alerts {
 		var (
 			result sql.Result
@@ -84,24 +84,86 @@ func insertAlerts(ctx context.Context, tx *sql.Tx, alertGroupID int64, alerts []
 			return fmt.Errorf("failed to get Alert inserted id: %w", err)
 		}
 
-		if err := insertKV(ctx, tx, "AlertLabel (AlertID, Label, Value)", alertID, alert.Labels); err != nil {
+		if err := insertAlertLabelsMySQL(ctx, tx, alertID, alert.Labels); err != nil {
 			return err
 		}
-		if err := insertKV(ctx, tx, "AlertAnnotation (AlertID, Annotation, Value)", alertID, alert.Annotations); err != nil {
+		if err := insertAlertAnnotationsMySQL(ctx, tx, alertID, alert.Annotations); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// insertKV inserts a map of key/value rows into a (id, key, value) table using
-// MySQL placeholder syntax. table is a compile-time constant supplied by this
-// package, never user input.
-func insertKV(ctx context.Context, tx *sql.Tx, table string, id int64, kv map[string]string) error {
+func insertGroupLabelsMySQL(ctx context.Context, tx *sql.Tx, alertGroupID int64, kv map[string]string) error {
 	for k, v := range kv {
-		//nolint:gosec // table is a package-internal constant, not user input
-		if _, err := tx.ExecContext(ctx, "INSERT INTO "+table+" VALUES (?, ?, ?)", id, k, v); err != nil {
-			return fmt.Errorf("failed to insert into %s: %w", table, err)
+		kvID, err := mysqlGetLabelKVID(ctx, tx, k, v)
+		if err != nil {
+			return fmt.Errorf("failed to resolve GroupLabel LabelKV: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO GroupLabel (alertGroupID, LabelKVID)
+			VALUES (?, ?)`, alertGroupID, kvID); err != nil {
+			return fmt.Errorf("failed to insert into GroupLabel: %w", err)
+		}
+	}
+	return nil
+}
+
+func insertCommonLabelsMySQL(ctx context.Context, tx *sql.Tx, alertGroupID int64, kv map[string]string) error {
+	for k, v := range kv {
+		kvID, err := mysqlGetLabelKVID(ctx, tx, k, v)
+		if err != nil {
+			return fmt.Errorf("failed to resolve CommonLabel LabelKV: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO CommonLabel (alertGroupID, LabelKVID)
+			VALUES (?, ?)`, alertGroupID, kvID); err != nil {
+			return fmt.Errorf("failed to insert into CommonLabel: %w", err)
+		}
+	}
+	return nil
+}
+
+func insertCommonAnnotationsMySQL(ctx context.Context, tx *sql.Tx, alertGroupID int64, kv map[string]string) error {
+	for k, v := range kv {
+		kvID, err := mysqlGetAnnotationKVID(ctx, tx, k, v)
+		if err != nil {
+			return fmt.Errorf("failed to resolve CommonAnnotation AnnotationKV: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO CommonAnnotation (alertGroupID, AnnotationKVID)
+			VALUES (?, ?)`, alertGroupID, kvID); err != nil {
+			return fmt.Errorf("failed to insert into CommonAnnotation: %w", err)
+		}
+	}
+	return nil
+}
+
+func insertAlertLabelsMySQL(ctx context.Context, tx *sql.Tx, alertID int64, kv map[string]string) error {
+	for k, v := range kv {
+		kvID, err := mysqlGetLabelKVID(ctx, tx, k, v)
+		if err != nil {
+			return fmt.Errorf("failed to resolve AlertLabel LabelKV: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO AlertLabel (AlertID, LabelKVID)
+			VALUES (?, ?)`, alertID, kvID); err != nil {
+			return fmt.Errorf("failed to insert into AlertLabel: %w", err)
+		}
+	}
+	return nil
+}
+
+func insertAlertAnnotationsMySQL(ctx context.Context, tx *sql.Tx, alertID int64, kv map[string]string) error {
+	for k, v := range kv {
+		kvID, err := mysqlGetAnnotationKVID(ctx, tx, k, v)
+		if err != nil {
+			return fmt.Errorf("failed to resolve AlertAnnotation AnnotationKV: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO AlertAnnotation (AlertID, AnnotationKVID)
+			VALUES (?, ?)`, alertID, kvID); err != nil {
+			return fmt.Errorf("failed to insert into AlertAnnotation: %w", err)
 		}
 	}
 	return nil

--- a/internal/storage/sqlstore/postgres.go
+++ b/internal/storage/sqlstore/postgres.go
@@ -30,11 +30,24 @@ func ConnectPostgres(cfg Config) (*Postgres, error) {
 // Save persists an alert group. extraLabels is ignored by SQL backends.
 func (d *Postgres) Save(ctx context.Context, data *internal.AlertGroup, _ map[string]string) error {
 	err := d.unitOfWork(ctx, func(tx *sql.Tx) error {
+		receiverID, err := postgresGetReceiverID(ctx, tx, data.Receiver)
+		if err != nil {
+			return fmt.Errorf("failed to resolve AlertGroup AlertGroupReceiver: %w", err)
+		}
+		externalURLID, err := postgresGetExternalURLID(ctx, tx, data.ExternalURL)
+		if err != nil {
+			return fmt.Errorf("failed to resolve AlertGroup AlertGroupExternalURL: %w", err)
+		}
+		groupKeyID, err := postgresGetKeyID(ctx, tx, data.GroupKey)
+		if err != nil {
+			return fmt.Errorf("failed to resolve AlertGroup AlertGroupKey: %w", err)
+		}
+
 		var alertGroupID int64
-		err := tx.QueryRowContext(ctx, `
-			INSERT INTO AlertGroup (time, receiver, status, externalURL, groupKey)
+		err = tx.QueryRowContext(ctx, `
+			INSERT INTO AlertGroup (time, status, ReceiverID, ExternalURLID, KeyID)
 			VALUES (current_timestamp, $1, $2, $3, $4) RETURNING ID`,
-			data.Receiver, data.Status, data.ExternalURL, data.GroupKey).Scan(&alertGroupID)
+			data.Status, receiverID, externalURLID, groupKeyID).Scan(&alertGroupID)
 		if err != nil {
 			return fmt.Errorf("failed to insert into AlertGroups: %w", err)
 		}

--- a/internal/storage/sqlstore/postgres.go
+++ b/internal/storage/sqlstore/postgres.go
@@ -39,17 +39,17 @@ func (d *Postgres) Save(ctx context.Context, data *internal.AlertGroup, _ map[st
 			return fmt.Errorf("failed to insert into AlertGroups: %w", err)
 		}
 
-		if err := insertKVPG(ctx, tx, "GroupLabel (alertGroupID, GroupLabel, Value)", alertGroupID, data.GroupLabels); err != nil {
+		if err := insertGroupLabelsPostgres(ctx, tx, alertGroupID, data.GroupLabels); err != nil {
 			return err
 		}
-		if err := insertKVPG(ctx, tx, "CommonLabel (alertGroupID, Label, Value)", alertGroupID, data.CommonLabels); err != nil {
+		if err := insertCommonLabelsPostgres(ctx, tx, alertGroupID, data.CommonLabels); err != nil {
 			return err
 		}
-		if err := insertKVPG(ctx, tx, "CommonAnnotation (alertGroupID, Annotation, Value)", alertGroupID, data.CommonAnnotations); err != nil {
+		if err := insertCommonAnnotationsPostgres(ctx, tx, alertGroupID, data.CommonAnnotations); err != nil {
 			return err
 		}
 
-		return insertAlertsPG(ctx, tx, alertGroupID, data.Alerts)
+		return insertAlertsPostgres(ctx, tx, alertGroupID, data.Alerts)
 	})
 	metrics.RecordSaveOutcome(data.Receiver, data.Status, len(data.Alerts), err)
 	return err
@@ -57,7 +57,7 @@ func (d *Postgres) Save(ctx context.Context, data *internal.AlertGroup, _ map[st
 
 func (*Postgres) String() string { return "postgres database driver" }
 
-func insertAlertsPG(ctx context.Context, tx *sql.Tx, alertGroupID int64, alerts []internal.Alert) error {
+func insertAlertsPostgres(ctx context.Context, tx *sql.Tx, alertGroupID int64, alerts []internal.Alert) error {
 	for _, alert := range alerts {
 		var row *sql.Row
 		if alert.EndsAt.Before(alert.StartsAt) {
@@ -76,24 +76,86 @@ func insertAlertsPG(ctx context.Context, tx *sql.Tx, alertGroupID int64, alerts 
 			return fmt.Errorf("failed to insert into Alert: %w", err)
 		}
 
-		if err := insertKVPG(ctx, tx, "AlertLabel (AlertID, Label, Value)", alertID, alert.Labels); err != nil {
+		if err := insertAlertLabelsPostgres(ctx, tx, alertID, alert.Labels); err != nil {
 			return err
 		}
-		if err := insertKVPG(ctx, tx, "AlertAnnotation (AlertID, Annotation, Value)", alertID, alert.Annotations); err != nil {
+		if err := insertAlertAnnotationsPostgres(ctx, tx, alertID, alert.Annotations); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// insertKVPG inserts a map of key/value rows into a (id, key, value) table
-// using Postgres placeholder syntax. table is a compile-time constant supplied
-// by this package, never user input.
-func insertKVPG(ctx context.Context, tx *sql.Tx, table string, id int64, kv map[string]string) error {
+func insertGroupLabelsPostgres(ctx context.Context, tx *sql.Tx, alertGroupID int64, kv map[string]string) error {
 	for k, v := range kv {
-		//nolint:gosec // table is a package-internal constant, not user input
-		if _, err := tx.ExecContext(ctx, "INSERT INTO "+table+" VALUES ($1, $2, $3)", id, k, v); err != nil {
-			return fmt.Errorf("failed to insert into %s: %w", table, err)
+		kvID, err := postgresGetLabelKVID(ctx, tx, k, v)
+		if err != nil {
+			return fmt.Errorf("failed to resolve GroupLabel LabelKV: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO GroupLabel (alertGroupID, LabelKVID)
+			VALUES ($1, $2)`, alertGroupID, kvID); err != nil {
+			return fmt.Errorf("failed to insert into GroupLabel: %w", err)
+		}
+	}
+	return nil
+}
+
+func insertCommonLabelsPostgres(ctx context.Context, tx *sql.Tx, alertGroupID int64, kv map[string]string) error {
+	for k, v := range kv {
+		kvID, err := postgresGetLabelKVID(ctx, tx, k, v)
+		if err != nil {
+			return fmt.Errorf("failed to resolve CommonLabel LabelKV: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO CommonLabel (alertGroupID, LabelKVID)
+			VALUES ($1, $2)`, alertGroupID, kvID); err != nil {
+			return fmt.Errorf("failed to insert into CommonLabel: %w", err)
+		}
+	}
+	return nil
+}
+
+func insertCommonAnnotationsPostgres(ctx context.Context, tx *sql.Tx, alertGroupID int64, kv map[string]string) error {
+	for k, v := range kv {
+		kvID, err := postgresGetAnnotationKVID(ctx, tx, k, v)
+		if err != nil {
+			return fmt.Errorf("failed to resolve CommonAnnotation AnnotationKV: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO CommonAnnotation (alertGroupID, AnnotationKVID)
+			VALUES ($1, $2)`, alertGroupID, kvID); err != nil {
+			return fmt.Errorf("failed to insert into CommonAnnotation: %w", err)
+		}
+	}
+	return nil
+}
+
+func insertAlertLabelsPostgres(ctx context.Context, tx *sql.Tx, alertID int64, kv map[string]string) error {
+	for k, v := range kv {
+		kvID, err := postgresGetLabelKVID(ctx, tx, k, v)
+		if err != nil {
+			return fmt.Errorf("failed to resolve AlertLabel LabelKV: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO AlertLabel (AlertID, LabelKVID)
+			VALUES ($1, $2)`, alertID, kvID); err != nil {
+			return fmt.Errorf("failed to insert into AlertLabel: %w", err)
+		}
+	}
+	return nil
+}
+
+func insertAlertAnnotationsPostgres(ctx context.Context, tx *sql.Tx, alertID int64, kv map[string]string) error {
+	for k, v := range kv {
+		kvID, err := postgresGetAnnotationKVID(ctx, tx, k, v)
+		if err != nil {
+			return fmt.Errorf("failed to resolve AlertAnnotation AnnotationKV: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO AlertAnnotation (AlertID, AnnotationKVID)
+			VALUES ($1, $2)`, alertID, kvID); err != nil {
+			return fmt.Errorf("failed to insert into AlertAnnotation: %w", err)
 		}
 	}
 	return nil

--- a/internal/storage/sqlstore/sqlstore.go
+++ b/internal/storage/sqlstore/sqlstore.go
@@ -16,7 +16,7 @@ import (
 )
 
 // SupportedModel is the database schema version this application understands.
-const SupportedModel = "0.2.0"
+const SupportedModel = "0.3.0"
 
 // Config holds connection-pool settings shared by the SQL backends.
 type Config struct {

--- a/internal/storage/sqlstore/sqlstore.go
+++ b/internal/storage/sqlstore/sqlstore.go
@@ -16,7 +16,7 @@ import (
 )
 
 // SupportedModel is the database schema version this application understands.
-const SupportedModel = "0.1.0"
+const SupportedModel = "0.2.0"
 
 // Config holds connection-pool settings shared by the SQL backends.
 type Config struct {


### PR DESCRIPTION
Hi,

This allows to deduplicate a redundant labels and annotations to be saved only once to the database, reducing usage of resource usage of the database server.

Please note, that this is a breaking change, which is incompatible with previous versions of alertsnitch.
Before upgrading, please run the sql statements in the following files, which will update the database schemas:
For MySQL:
```
database/mysql/0.2.0-labelkv.sql
database/mysql/0.3.0-alertgroup-kv.sql
```
For PostgreSQL:
```
database/postgres/0.2.0-labelkv.sql
database/postgres/0.3.0-alertgroup-kv.sql
```