### PR TITLE
fix(loki): stamp entries at webhook receive time, not alert StartsAt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,10 +89,16 @@ direction is one-way: `internal` (leaf: domain model + interfaces) ← `internal
   explodes Loki's active-stream count. Label *names* are validated (`isValidLabelName`) at the single
   chokepoint `buildStreamLabels`, so a stray `?app-id=x` query param can't make Loki reject the whole
   push. One stream per `alert_status`.
-- **Timestamps** use the alert's real `StartsAt`/`EndsAt`, not `time.Now()`. `ensureMonotonic`
-  (`timestamps.go`) sorts each stream's entries ascending and nudges colliding timestamps forward 1ns
-  so Loki doesn't silently drop alerts that share a `StartsAt`; applied on the sync path and after
-  `mergeStreams` (cross-group collisions).
+- **Timestamps**: the Loki entry timestamp is the **webhook receive time**, stamped once in
+  `Save` and carried through the batch queue and the WAL (`walRecord.ReceivedAt`) so a replay
+  reproduces the identical entry. It is **not** the alert's `StartsAt`: Loki is ingest-ordered, so an
+  alert that has been firing for a while is rejected outright (`reject_old_samples`, or the per-stream
+  "entry too far behind" window) or lands outside `retention_period` — an alert firing longer than
+  retention would be written straight into an expired window. Nothing is lost: `startsAt`/`endsAt`
+  travel in the JSON log line. `ensureMonotonic` (`timestamps.go`) sorts each stream's entries
+  ascending and nudges colliding timestamps forward 1ns so Loki doesn't silently drop the alerts of a
+  group (which all share one receive time); applied on the sync path and after `mergeStreams`
+  (cross-group collisions).
 - **Structured metadata** (`ALERTSNITCH_LOKI_STRUCTURED_METADATA`, opt-in): attaches a curated set of
   high-value fields (`fingerprint` + the high-card labels kept out of stream labels) as Loki 3.x
   structured metadata (the optional 3rd tuple element in `row`), for fast filtering without stream
@@ -105,7 +111,8 @@ direction is one-way: `internal` (leaf: domain model + interfaces) ← `internal
   only when its batch reaches a terminal outcome; a contiguous-ack checkpoint + compaction bound the
   log. On startup, records past the checkpoint are replayed. Crash-durable, **at-least-once** (a crash
   between push and checkpoint replays already-delivered alerts — tolerated because timestamp
-  de-collision + Loki dedup absorb duplicates).
+  de-collision + Loki dedup absorb duplicates; the persisted `ReceivedAt` is what makes a replayed
+  entry byte-identical, and therefore droppable, rather than a second copy).
 - **Persistence metrics**: the backend records `saved_total`/`saving_failures_total` at the *real*
   point of durability (synchronously, or at batch-flush resolution). Queue-full drops count as
   failures. The server does **not** double-count these — it owns only received/invalid + the gauge.

--- a/internal/storage/loki/batch.go
+++ b/internal/storage/loki/batch.go
@@ -12,11 +12,15 @@ import (
 )
 
 // queuedAlert is one alert group awaiting batched delivery, together with the
-// per-request labels captured when it was enqueued. seq is its WAL sequence
-// number (0 when the WAL is disabled), used to acknowledge it once delivered.
+// per-request labels captured when it was enqueued. receivedAt is the webhook
+// arrival time, stamped in Save and carried here so a flush — or a WAL replay
+// after a crash — reproduces the same Loki entry timestamp. seq is its WAL
+// sequence number (0 when the WAL is disabled), used to acknowledge it once
+// delivered.
 type queuedAlert struct {
 	group       *internal.AlertGroup
 	extraLabels map[string]string
+	receivedAt  time.Time
 	seq         uint64
 }
 
@@ -91,7 +95,7 @@ func (b *batchProcessor) start() {
 // space, but AlertManager (the expected client) does not cancel mid-request.
 func (b *batchProcessor) enqueue(ctx context.Context, qa queuedAlert) error {
 	if b.wal != nil {
-		seq, err := b.wal.append(qa.group, qa.extraLabels)
+		seq, err := b.wal.append(qa.group, qa.extraLabels, qa.receivedAt)
 		if err != nil {
 			logrus.Errorf("Failed to write alert to Loki WAL: %v", err)
 			recordOutcome(qa.group.Receiver, qa.group.Status, len(qa.group.Alerts), err)
@@ -133,7 +137,7 @@ func (b *batchProcessor) replay(records []walRecord) {
 		defer b.wg.Done()
 		for _, rec := range records {
 			select {
-			case b.in <- queuedAlert{group: rec.Group, extraLabels: rec.ExtraLabels, seq: rec.Seq}:
+			case b.in <- queuedAlert{group: rec.Group, extraLabels: rec.ExtraLabels, receivedAt: rec.ReceivedAt, seq: rec.Seq}:
 			case <-b.stopCh:
 				return
 			}
@@ -223,7 +227,7 @@ func (b *batchProcessor) flush(batch []queuedAlert) {
 	// group's (possibly successful) delivery outcome.
 	ready := make([]convertedGroup, 0, len(batch))
 	for _, qa := range batch {
-		streams, err := b.client.dataToStream(qa.group, qa.extraLabels)
+		streams, err := b.client.dataToStream(qa.group, qa.extraLabels, qa.receivedAt)
 		if err != nil {
 			logrus.Errorf("Error converting data to stream: %v", err)
 			recordOutcome(qa.group.Receiver, qa.group.Status, len(qa.group.Alerts), err)

--- a/internal/storage/loki/client.go
+++ b/internal/storage/loki/client.go
@@ -88,15 +88,23 @@ func New(cfg Config) (*Client, error) {
 // Save persists an alert group. In batch mode it enqueues the group and the
 // background processor ships and accounts for it; otherwise it ships
 // synchronously and records the outcome immediately.
+//
+// The receive time is stamped once, here, and carried through the batch queue
+// and the WAL. Stamping it later (at flush) would give a WAL record a fresh
+// timestamp on replay, so Loki could no longer drop the byte-identical repeat —
+// the at-least-once guarantee relies on a replayed entry being reproducible.
 func (c *Client) Save(ctx context.Context, data *internal.AlertGroup, extraLabels map[string]string) error {
+	receivedAt := time.Now()
+
 	if c.batch != nil {
 		return c.batch.enqueue(ctx, queuedAlert{
 			group:       data,
 			extraLabels: extraLabels,
+			receivedAt:  receivedAt,
 		})
 	}
 
-	streams, err := c.dataToStream(data, extraLabels)
+	streams, err := c.dataToStream(data, extraLabels, receivedAt)
 	if err != nil {
 		recordOutcome(data.Receiver, data.Status, len(data.Alerts), err)
 		return fmt.Errorf("error converting data to stream: %w", err)

--- a/internal/storage/loki/loki_test.go
+++ b/internal/storage/loki/loki_test.go
@@ -283,9 +283,10 @@ func TestSave_BatchWALReplaysRecoveredAlerts(t *testing.T) {
 
 	// Simulate a crash: a previous process durably logged an alert but died
 	// before flushing it (no ack).
+	received := time.Now().Add(-2 * time.Hour)
 	seed, err := openWAL(dir)
 	require.NoError(t, err)
-	_, err = seed.append(walGroup("wal-replay"), map[string]string{"source": "am"})
+	_, err = seed.append(walGroup("wal-replay"), map[string]string{"source": "am"}, received)
 	require.NoError(t, err)
 	require.NoError(t, seed.close())
 
@@ -310,6 +311,15 @@ func TestSave_BatchWALReplaysRecoveredAlerts(t *testing.T) {
 
 	require.NoError(t, client.Close(context.Background()))
 	assert.Equal(t, saved+1, testutil.ToFloat64(metrics.AlertsSavedTotal.WithLabelValues("wal-replay", "firing")))
+
+	// The replayed entry keeps the timestamp it was accepted with, so Loki drops
+	// it as a byte-identical duplicate of the push this process may have already
+	// made before crashing. Stamping the flush time here would defeat that.
+	pushed := fake.streams()
+	require.Len(t, pushed, 1)
+	require.Len(t, pushed[0].Values, 1)
+	assert.Equal(t, received.UnixNano(), pushed[0].Values[0].At.UnixNano(),
+		"a replayed alert must be pushed at its original receive time")
 
 	// The replayed record is now acknowledged: a fresh open recovers nothing.
 	reopened, err := openWAL(dir)

--- a/internal/storage/loki/stream.go
+++ b/internal/storage/loki/stream.go
@@ -30,9 +30,15 @@ func groupAlertsByStatus(alerts []internal.Alert) map[string][]internal.Alert {
 }
 
 // dataToStream converts an alert group into one Loki stream per alert status.
-func (c *Client) dataToStream(data *internal.AlertGroup, extraLabels map[string]string) ([]stream, error) {
+// Every entry is stamped with receivedAt, the moment the webhook was accepted.
+// A zero receivedAt (a WAL record written before it was persisted) falls back to
+// the current time.
+func (c *Client) dataToStream(data *internal.AlertGroup, extraLabels map[string]string, receivedAt time.Time) ([]stream, error) {
 	if len(data.Alerts) == 0 {
 		return nil, fmt.Errorf("no alerts to process")
+	}
+	if receivedAt.IsZero() {
+		receivedAt = time.Now()
 	}
 
 	byStatus := groupAlertsByStatus(data.Alerts)
@@ -40,7 +46,7 @@ func (c *Client) dataToStream(data *internal.AlertGroup, extraLabels map[string]
 
 	streams := make([]stream, 0, len(byStatus))
 	for status, alerts := range byStatus {
-		s, err := c.createStreamForStatus(status, alerts, data, baseLabels)
+		s, err := c.createStreamForStatus(status, alerts, data, baseLabels, receivedAt)
 		if err != nil {
 			return nil, err
 		}
@@ -49,7 +55,7 @@ func (c *Client) dataToStream(data *internal.AlertGroup, extraLabels map[string]
 	return streams, nil
 }
 
-func (c *Client) createStreamForStatus(status string, alerts []internal.Alert, data *internal.AlertGroup, baseLabels map[string]string) (stream, error) {
+func (c *Client) createStreamForStatus(status string, alerts []internal.Alert, data *internal.AlertGroup, baseLabels map[string]string, receivedAt time.Time) (stream, error) {
 	streamLabels := cloneLabels(baseLabels)
 	streamLabels["alert_status"] = status
 
@@ -59,16 +65,6 @@ func (c *Client) createStreamForStatus(status string, alerts []internal.Alert, d
 	}
 
 	for _, alert := range alerts {
-		// Use the alert's real timestamp rather than time.Now() so history is
-		// accurate: StartsAt for firing, EndsAt for resolved when valid.
-		timestamp := alert.StartsAt
-		if status == "resolved" && !alert.EndsAt.IsZero() && alert.EndsAt.After(alert.StartsAt) {
-			timestamp = alert.EndsAt
-		}
-		if timestamp.IsZero() {
-			timestamp = time.Now()
-		}
-
 		flattened := FlattenAlertGroup{
 			Version:           data.Version,
 			GroupKey:          data.GroupKey,
@@ -90,11 +86,16 @@ func (c *Client) createStreamForStatus(status string, alerts []internal.Alert, d
 		if c.cfg.StructuredMetadata {
 			meta = buildAlertMetadata(alert)
 		}
-		s.Values = append(s.Values, row{At: timestamp, Val: string(jsonData), Meta: meta})
+		// The entry timestamp is when AlertManager notified us, not when the alert
+		// started: Loki is ingest-ordered, and an alert that has been firing for
+		// days would be rejected outright (reject_old_samples / "entry too far
+		// behind") or land outside the retention window. The alert's own StartsAt
+		// and EndsAt travel in the JSON log line, so no information is lost.
+		s.Values = append(s.Values, row{At: receivedAt, Val: string(jsonData), Meta: meta})
 	}
 
-	// Colliding StartsAt values within a group are common; keep every entry by
-	// giving each a strictly increasing, unique nanosecond timestamp.
+	// Every entry in the group shares one receive time; keep them all by giving
+	// each a strictly increasing, unique nanosecond timestamp.
 	s.Values = ensureMonotonic(s.Values)
 	return s, nil
 }

--- a/internal/storage/loki/unit_test.go
+++ b/internal/storage/loki/unit_test.go
@@ -171,14 +171,14 @@ func TestDataToStream_StructuredMetadataToggle(t *testing.T) {
 	}
 
 	t.Run("disabled by default", func(t *testing.T) {
-		streams, err := (&Client{allowedLabels: allowedLabelSet(nil)}).dataToStream(ag, nil)
+		streams, err := (&Client{allowedLabels: allowedLabelSet(nil)}).dataToStream(ag, nil, time.Now())
 		require.NoError(t, err)
 		assert.Nil(t, streams[0].Values[0].Meta, "metadata must be absent when disabled")
 	})
 
 	t.Run("enabled attaches metadata", func(t *testing.T) {
 		c := &Client{allowedLabels: allowedLabelSet(nil), cfg: Config{StructuredMetadata: true}}
-		streams, err := c.dataToStream(ag, nil)
+		streams, err := c.dataToStream(ag, nil, time.Now())
 		require.NoError(t, err)
 		assert.Equal(t, "p1", streams[0].Values[0].Meta["pod"])
 		assert.Equal(t, "fp", streams[0].Values[0].Meta["fingerprint"])
@@ -189,9 +189,10 @@ func testClient(allowed ...string) *Client {
 	return &Client{allowedLabels: allowedLabelSet(allowed)}
 }
 
-func TestDataToStream_GroupsByStatusAndUsesAlertTimestamps(t *testing.T) {
+func TestDataToStream_GroupsByStatusAndUsesReceiveTime(t *testing.T) {
 	start := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
 	end := start.Add(time.Hour)
+	received := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
 
 	ag := &internal.AlertGroup{
 		Version:      "4",
@@ -204,7 +205,7 @@ func TestDataToStream_GroupsByStatusAndUsesAlertTimestamps(t *testing.T) {
 		},
 	}
 
-	streams, err := testClient().dataToStream(ag, nil)
+	streams, err := testClient().dataToStream(ag, nil, received)
 	require.NoError(t, err)
 	require.Len(t, streams, 2, "one stream per status")
 
@@ -215,12 +216,63 @@ func TestDataToStream_GroupsByStatusAndUsesAlertTimestamps(t *testing.T) {
 
 	require.Contains(t, byStatus, "firing")
 	require.Contains(t, byStatus, "resolved")
-	assert.Equal(t, start.UnixNano(), byStatus["firing"].Values[0].At.UnixNano(), "firing uses StartsAt")
-	assert.Equal(t, end.UnixNano(), byStatus["resolved"].Values[0].At.UnixNano(), "resolved uses EndsAt")
+	assert.Equal(t, received.UnixNano(), byStatus["firing"].Values[0].At.UnixNano(), "firing entry is stamped at receive time")
+	assert.Equal(t, received.UnixNano(), byStatus["resolved"].Values[0].At.UnixNano(), "resolved entry is stamped at receive time")
+}
+
+// TestDataToStream_OldAlertUsesReceiveTime is the regression test for the 1.1.0
+// rollout failure: an alert that has been firing for months must not be pushed
+// at its StartsAt, or Loki rejects it (reject_old_samples / entry too far
+// behind) and the alert history is silently lost. The alert's own StartsAt and
+// EndsAt stay in the JSON log line, so nothing is lost by stamping receive time.
+func TestDataToStream_OldAlertUsesReceiveTime(t *testing.T) {
+	start := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC) // ~6 months before receipt
+	received := time.Date(2026, 7, 9, 4, 32, 9, 0, time.UTC)
+
+	ag := &internal.AlertGroup{
+		Version:      "4",
+		Receiver:     "r",
+		Status:       "firing",
+		CommonLabels: map[string]string{"alertname": "X"},
+		Alerts: internal.Alerts{
+			{Status: "firing", StartsAt: start},
+		},
+	}
+
+	streams, err := testClient().dataToStream(ag, nil, received)
+	require.NoError(t, err)
+	require.Len(t, streams, 1)
+	require.Len(t, streams[0].Values, 1)
+
+	entry := streams[0].Values[0]
+	assert.Equal(t, received.UnixNano(), entry.At.UnixNano(), "entry timestamp must be the receive time, not StartsAt")
+
+	var line FlattenAlertGroup
+	require.NoError(t, json.Unmarshal([]byte(entry.Val), &line))
+	assert.True(t, line.Alert.StartsAt.Equal(start), "the alert's real StartsAt must still be queryable in the log line")
+}
+
+// TestDataToStream_ZeroReceivedAtFallsBackToNow covers WAL records written by an
+// older version, which carry no receivedAt.
+func TestDataToStream_ZeroReceivedAtFallsBackToNow(t *testing.T) {
+	ag := &internal.AlertGroup{
+		Version:      "4",
+		Receiver:     "r",
+		Status:       "firing",
+		CommonLabels: map[string]string{"alertname": "X"},
+		Alerts:       internal.Alerts{{Status: "firing"}},
+	}
+
+	before := time.Now()
+	streams, err := testClient().dataToStream(ag, nil, time.Time{})
+	require.NoError(t, err)
+	at := streams[0].Values[0].At
+	assert.False(t, at.Before(before), "a zero receivedAt must fall back to now")
+	assert.False(t, at.After(time.Now()), "a zero receivedAt must fall back to now")
 }
 
 func TestDataToStream_EmptyAlertsIsError(t *testing.T) {
-	_, err := testClient().dataToStream(&internal.AlertGroup{}, nil)
+	_, err := testClient().dataToStream(&internal.AlertGroup{}, nil, time.Now())
 	assert.Error(t, err)
 }
 
@@ -260,8 +312,8 @@ func TestEnsureMonotonic(t *testing.T) {
 }
 
 // TestDataToStream_CollidingTimestampsArePreserved is the regression test for
-// the silent-drop bug: several alerts with the same StartsAt in one status must
-// each land at a unique timestamp so Loki keeps them all.
+// the silent-drop bug: every alert in a group is stamped at the same receive
+// time, so each must be nudged to a unique timestamp for Loki to keep them all.
 func TestDataToStream_CollidingTimestampsArePreserved(t *testing.T) {
 	start := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
 	ag := &internal.AlertGroup{
@@ -276,7 +328,7 @@ func TestDataToStream_CollidingTimestampsArePreserved(t *testing.T) {
 		},
 	}
 
-	streams, err := testClient().dataToStream(ag, nil)
+	streams, err := testClient().dataToStream(ag, nil, time.Now())
 	require.NoError(t, err)
 	require.Len(t, streams, 1)
 

--- a/internal/storage/loki/wal.go
+++ b/internal/storage/loki/wal.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -26,7 +27,9 @@ import (
 // Semantics are at-least-once: a crash after a successful push but before the
 // checkpoint advances replays already-delivered alerts. Duplicates are tolerable
 // here — the timestamp de-collision (timestamps.go) keeps entries unique and
-// Loki itself drops byte-identical (timestamp, line) repeats.
+// Loki itself drops byte-identical (timestamp, line) repeats. That last part is
+// why each record persists its ReceivedAt: a replay must reproduce the original
+// entry timestamp, or Loki sees a distinct entry and stores it twice.
 const (
 	walLogName      = "wal.log"
 	walCheckpoint   = "wal.ckpt"
@@ -38,11 +41,15 @@ const (
 // closed (during shutdown) or left nil by a failed compaction swap.
 var errWALClosed = errors.New("loki wal is closed")
 
-// walRecord is one durably-logged alert awaiting delivery.
+// walRecord is one durably-logged alert awaiting delivery. ReceivedAt is
+// persisted so a replayed record is pushed at the timestamp it originally had;
+// records written before this field existed decode to the zero time, which
+// dataToStream treats as "stamp it now".
 type walRecord struct {
 	Seq         uint64               `json:"seq"`
 	Group       *internal.AlertGroup `json:"group"`
 	ExtraLabels map[string]string    `json:"extraLabels,omitempty"`
+	ReceivedAt  time.Time            `json:"receivedAt,omitzero"`
 }
 
 // wal is an append-only write-ahead log with a contiguous-ack checkpoint. It is
@@ -115,7 +122,7 @@ func (w *wal) recover() []walRecord {
 
 // append durably writes one record and returns its assigned sequence number.
 // The data is fsync'd before returning so a crash cannot lose an accepted alert.
-func (w *wal) append(group *internal.AlertGroup, extraLabels map[string]string) (uint64, error) {
+func (w *wal) append(group *internal.AlertGroup, extraLabels map[string]string, receivedAt time.Time) (uint64, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -124,7 +131,7 @@ func (w *wal) append(group *internal.AlertGroup, extraLabels map[string]string) 
 	}
 
 	w.seq++
-	rec := walRecord{Seq: w.seq, Group: group, ExtraLabels: extraLabels}
+	rec := walRecord{Seq: w.seq, Group: group, ExtraLabels: extraLabels, ReceivedAt: receivedAt}
 	body, err := json.Marshal(rec)
 	if err != nil {
 		w.seq-- // nothing was written; keep sequence numbers gap-free

--- a/internal/storage/loki/wal_test.go
+++ b/internal/storage/loki/wal_test.go
@@ -1,9 +1,11 @@
 package loki
 
 import (
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,9 +29,9 @@ func TestWAL_AppendRecoverAck(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, w.recover(), "fresh WAL has nothing to recover")
 
-	s1, err := w.append(walGroup("a"), map[string]string{"src": "am"})
+	s1, err := w.append(walGroup("a"), map[string]string{"src": "am"}, time.Now())
 	require.NoError(t, err)
-	s2, err := w.append(walGroup("b"), nil)
+	s2, err := w.append(walGroup("b"), nil, time.Now())
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1), s1)
 	assert.Equal(t, uint64(2), s2)
@@ -60,7 +62,7 @@ func TestWAL_ContiguousCheckpointOnly(t *testing.T) {
 	w, err := openWAL(dir)
 	require.NoError(t, err)
 	for i := 0; i < 3; i++ {
-		_, err := w.append(walGroup("r"), nil)
+		_, err := w.append(walGroup("r"), nil, time.Now())
 		require.NoError(t, err)
 	}
 
@@ -84,7 +86,7 @@ func TestWAL_TruncatedTailIsIgnored(t *testing.T) {
 	dir := t.TempDir()
 	w, err := openWAL(dir)
 	require.NoError(t, err)
-	_, err = w.append(walGroup("ok"), nil)
+	_, err = w.append(walGroup("ok"), nil, time.Now())
 	require.NoError(t, err)
 	require.NoError(t, w.close())
 
@@ -112,7 +114,7 @@ func TestWAL_RecordTooLargeIsRejected(t *testing.T) {
 	huge := walGroup("big")
 	huge.CommonAnnotations = map[string]string{"description": string(make([]byte, walMaxRecordLen+1))}
 
-	_, err = w.append(huge, nil)
+	_, err = w.append(huge, nil, time.Now())
 	require.Error(t, err, "an oversized record must be rejected, not silently corrupt the log")
 	assert.Equal(t, uint64(0), w.seq, "a rejected append must not consume a sequence number")
 }
@@ -158,12 +160,12 @@ func TestWAL_OperationsAfterCloseAreSafe(t *testing.T) {
 	dir := t.TempDir()
 	w, err := openWAL(dir)
 	require.NoError(t, err)
-	s1, err := w.append(walGroup("r"), nil)
+	s1, err := w.append(walGroup("r"), nil, time.Now())
 	require.NoError(t, err)
 	require.NoError(t, w.close())
 
 	assert.NotPanics(t, func() {
-		_, appendErr := w.append(walGroup("r"), nil)
+		_, appendErr := w.append(walGroup("r"), nil, time.Now())
 		assert.ErrorIs(t, appendErr, errWALClosed, "append after close must report closed, not panic")
 		// ack after close must not panic even if it would otherwise compact.
 		_ = w.ack([]uint64{s1})
@@ -183,7 +185,7 @@ func TestWAL_Compaction(t *testing.T) {
 
 	var seqs []uint64
 	for i := 0; i < n; i++ {
-		s, err := w.append(big, nil)
+		s, err := w.append(big, nil, time.Now())
 		require.NoError(t, err)
 		seqs = append(seqs, s)
 	}
@@ -202,4 +204,64 @@ func TestWAL_Compaction(t *testing.T) {
 	require.Len(t, recovered, 1, "only the unacknowledged record survives compaction")
 	assert.Equal(t, uint64(n), recovered[0].Seq)
 	require.NoError(t, w2.close())
+}
+
+// TestWAL_ReceivedAtSurvivesReplay pins the property the at-least-once guarantee
+// rests on: a replayed record must produce the same Loki entry timestamp it had
+// on its first push, so Loki drops the byte-identical repeat instead of storing
+// the alert twice.
+func TestWAL_ReceivedAtSurvivesReplay(t *testing.T) {
+	dir := t.TempDir()
+	received := time.Date(2026, 7, 9, 4, 32, 9, 123456789, time.UTC)
+
+	w, err := openWAL(dir)
+	require.NoError(t, err)
+	_, err = w.append(walGroup("a"), nil, received)
+	require.NoError(t, err)
+	require.NoError(t, w.close())
+
+	w2, err := openWAL(dir)
+	require.NoError(t, err)
+	defer w2.close()
+
+	recovered := w2.recover()
+	require.Len(t, recovered, 1)
+	require.True(t, recovered[0].ReceivedAt.Equal(received), "receivedAt must round-trip through the WAL")
+
+	c := testClient()
+	first, err := c.dataToStream(walGroup("a"), nil, received)
+	require.NoError(t, err)
+	replayed, err := c.dataToStream(recovered[0].Group, recovered[0].ExtraLabels, recovered[0].ReceivedAt)
+	require.NoError(t, err)
+	assert.Equal(t, first[0].Values[0].At.UnixNano(), replayed[0].Values[0].At.UnixNano(),
+		"a replayed record must reproduce the original entry timestamp")
+	assert.Equal(t, first[0].Values[0].Val, replayed[0].Values[0].Val)
+}
+
+// TestWAL_LegacyRecordWithoutReceivedAt covers records written by a version that
+// did not persist receivedAt: they must still replay, stamped at push time.
+func TestWAL_LegacyRecordWithoutReceivedAt(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.OpenFile(filepath.Join(dir, walLogName), os.O_CREATE|os.O_WRONLY, 0o640)
+	require.NoError(t, err)
+	legacy := []byte(`{"seq":1,"group":{"receiver":"old","status":"firing","alerts":[{"status":"firing"}]}}`)
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(legacy)))
+	_, err = f.Write(append(lenBuf[:], legacy...))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	w, err := openWAL(dir)
+	require.NoError(t, err)
+	defer w.close()
+
+	recovered := w.recover()
+	require.Len(t, recovered, 1)
+	require.True(t, recovered[0].ReceivedAt.IsZero())
+
+	before := time.Now()
+	streams, err := testClient().dataToStream(recovered[0].Group, nil, recovered[0].ReceivedAt)
+	require.NoError(t, err)
+	at := streams[0].Values[0].At
+	assert.False(t, at.Before(before), "a legacy record is stamped at replay time")
 }


### PR DESCRIPTION
## Why

Shipping 1.1.0 to a real environment showed that using the alert's `StartsAt` as the Loki **entry timestamp** makes AlertSnitch unusable against a Loki with default ingestion limits.

Loki is ingest-ordered. Three independent failure modes follow from stamping `StartsAt`:

1. `reject_old_samples` (typically `reject_old_samples_max_age: 168h`) rejects any alert that has been firing for more than a week — HTTP 400, `timestamp too old`.
2. The per-stream out-of-order window rejects the rest with `entry too far behind`, because AlertManager re-sends a still-firing alert with the **same** `StartsAt` on every `repeat_interval` — so the stream's time axis never advances.
3. Independently of any Loki setting: an alert firing for longer than `retention_period` is written straight into an already-expired window, so it is stored and then never queryable.

Measured on one environment before the revert: of **715** firing alerts received in 180s, **7** were stored and **708** were dropped — 99% of alert history lost.

## What changed

The entry timestamp is now the **webhook receive time** — the event actually being logged is "AlertManager notified us at T", not "the alert started at StartsAt". Nothing is lost on the time axis: `startsAt` / `endsAt` already travel in the JSON log line (`FlattenAlertGroup` embeds `internal.Alert`), which is what dashboards read.

The receive time is stamped **once**, in `Save`, and carried through `queuedAlert` and the WAL (`walRecord.ReceivedAt`). This is load-bearing, not cosmetic: stamping it at flush would give a WAL record a fresh timestamp on replay, so Loki could no longer drop the byte-identical repeat, and the documented at-least-once tolerance ("timestamp de-collision + Loki dedup absorb duplicates") would silently become "every crash stores the alert twice". Records written by an earlier version carry no `receivedAt`, decode to the zero time, and are stamped at replay.

`ensureMonotonic` is unchanged and still needed — every alert in a group now shares one receive time, so the 1ns nudge is what keeps them all.

## Test plan

`go vet` and `go test -race ./...` are green. New/changed tests:

- `TestDataToStream_OldAlertUsesReceiveTime` — the regression test, built from the payload that failed in production (`StartsAt` ~6 months before receipt): asserts the entry timestamp is the receive time **and** that the real `StartsAt` is still present in the log line.
- `TestDataToStream_GroupsByStatusAndUsesReceiveTime` — replaces the test that asserted the old behavior.
- `TestDataToStream_ZeroReceivedAtFallsBackToNow`
- `TestWAL_ReceivedAtSurvivesReplay` — `receivedAt` round-trips through the WAL and a replayed record reproduces the original entry timestamp.
- `TestWAL_LegacyRecordWithoutReceivedAt` — a hand-written pre-`receivedAt` WAL frame still replays.
- `TestSave_BatchWALReplaysRecoveredAlerts` — extended to assert the replayed alert is pushed at its original receive time (covers the flush path end-to-end against `fakeLoki`).

Both directions were mutation-checked, so the tests are not vacuous:

- reinstating `At: alert.StartsAt` → the three `TestDataToStream_*` timestamp tests fail.
- changing `flush` to stamp `time.Now()` instead of `qa.receivedAt` → `TestSave_BatchWALReplaysRecoveredAlerts` fails.

Docs updated in the same change: the `stream.go` comment that argued for the old behavior, and the two CLAUDE.md claims it was based on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)